### PR TITLE
feat: add findMany funciton

### DIFF
--- a/lib/repository/find-option/find-many-option.ts
+++ b/lib/repository/find-option/find-many-option.ts
@@ -1,0 +1,8 @@
+import { FindOptionsWhere } from './find-option-where'
+import { FindOptionsOrder } from './find-options-order'
+
+export interface FindManyOption<Entity = any> {
+  where?: FindOptionsWhere<Entity>
+
+  order?: FindOptionsOrder<Entity>
+}

--- a/lib/repository/find-option/find-options-order.ts
+++ b/lib/repository/find-option/find-options-order.ts
@@ -1,16 +1,6 @@
 export type FindOptionsOrderProperty<Property> = Property extends Promise<
   infer I
 >
-  ? FindOptionsOrderProperty<NonNullable<I>>
-  : Property extends Array<infer I>
-  ? FindOptionsOrderProperty<NonNullable<I>>
-  : Property extends Function
-  ? never
-  : Property extends Buffer
-  ? FindOptionsOrderValue
-  : Property extends Date
-  ? FindOptionsOrderValue
-  : Property extends object
   ? FindOptionsOrder<Property>
   : FindOptionsOrderValue
 
@@ -18,14 +8,4 @@ export type FindOptionsOrder<Entity> = {
   [P in keyof Entity]?: FindOptionsOrderProperty<NonNullable<Entity[P]>>
 }
 
-export type FindOptionsOrderValue =
-  | 'ASC'
-  | 'DESC'
-  | 'asc'
-  | 'desc'
-  | 1
-  | -1
-  | {
-      direction?: 'asc' | 'desc' | 'ASC' | 'DESC'
-      nulls?: 'first' | 'last' | 'FIRST' | 'LAST'
-    }
+export type FindOptionsOrderValue = 'ASC' | 'DESC' | 'asc' | 'desc'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-spanner",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Cloud Spanner orm for Nest.js",
   "author": "tfunato",
   "private": false,

--- a/test/src/CompositeKeyTestRepository.ts
+++ b/test/src/CompositeKeyTestRepository.ts
@@ -1,5 +1,4 @@
 import { Repository } from '../../lib'
-import { Test } from './entity/Test'
 import { CompositeKeyTest } from './entity/CompositeKeyTest'
 
 export class CompositeKeyTestRepository extends Repository<CompositeKeyTest> {}

--- a/test/unit/repository/repository.findMany.test.ts
+++ b/test/unit/repository/repository.findMany.test.ts
@@ -6,8 +6,8 @@ jest.mock('../../../lib/service/transaction-manager')
 
 const TransactionManagerMock = TransactionManager as jest.Mock
 
-describe('repository composite key test', () => {
-  test('findOne composite key test', async () => {
+describe('repository findMany test', () => {
+  test('simple findMany test no order by', async () => {
     TransactionManagerMock.mockImplementationOnce(() => {
       return {
         getDb: (): any => {
@@ -18,7 +18,7 @@ describe('repository composite key test', () => {
               params: { id: number }
             }) => {
               expect(query.sql).toBe(
-                'SELECT id, idSub, a, b FROM CompositeKeyTests WHERE id=@id AND idSub=@idSub LIMIT 1',
+                'SELECT id, idSub, a, b FROM CompositeKeyTests WHERE id=@id AND idSub=@idSub',
               )
               expect(query.json).toBe(false)
               expect(query.params).toEqual({ id: 123, idSub: 'foo' })
@@ -46,7 +46,7 @@ describe('repository composite key test', () => {
       transactionManager,
       CompositeKeyTest,
     )
-    let actual: CompositeKeyTest | null = await target.findOne({
+    let actual: CompositeKeyTest[] = await target.findMany({
       where: {
         id: 123,
         idSub: 'foo',
@@ -56,10 +56,10 @@ describe('repository composite key test', () => {
     expectResult.id = 123
     expectResult.a = 'abcd'
     expectResult.b = 'efg'
-    expect(actual).toEqual(expectResult)
+    expect(actual).toEqual([expectResult])
   })
 
-  test('findOne simple key test', async () => {
+  test('findMany with order by test', async () => {
     TransactionManagerMock.mockImplementationOnce(() => {
       return {
         getDb: (): any => {
@@ -70,7 +70,7 @@ describe('repository composite key test', () => {
               params: { id: number }
             }) => {
               expect(query.sql).toBe(
-                'SELECT id, idSub, a, b FROM CompositeKeyTests WHERE id=@id LIMIT 1',
+                'SELECT id, idSub, a, b FROM CompositeKeyTests WHERE id=@id ORDER BY b asc, a DESC, idSub ASC',
               )
               expect(query.json).toBe(false)
               expect(query.params).toEqual({ id: 123 })
@@ -98,15 +98,20 @@ describe('repository composite key test', () => {
       transactionManager,
       CompositeKeyTest,
     )
-    let actual: CompositeKeyTest | null = await target.findOne({
+    let actual: CompositeKeyTest[] = await target.findMany({
       where: {
         id: 123,
+      },
+      order: {
+        b: 'asc',
+        a: 'DESC',
+        idSub: 'ASC',
       },
     })
     const expectResult = new CompositeKeyTest()
     expectResult.id = 123
     expectResult.a = 'abcd'
     expectResult.b = 'efg'
-    expect(actual).toEqual(expectResult)
+    expect(actual).toEqual([expectResult])
   })
 })

--- a/test/unit/repository/repository.findOne.test.ts
+++ b/test/unit/repository/repository.findOne.test.ts
@@ -1,0 +1,167 @@
+import { TransactionManager } from '../../../lib'
+import { CompositeKeyTestRepository } from '../../src/CompositeKeyTestRepository'
+import { CompositeKeyTest } from '../../src/entity/CompositeKeyTest'
+
+jest.mock('../../../lib/service/transaction-manager')
+
+const TransactionManagerMock = TransactionManager as jest.Mock
+
+describe('repository composite key test', () => {
+  test('findOne composite key test', async () => {
+    TransactionManagerMock.mockImplementationOnce(() => {
+      return {
+        getDb: (): any => {
+          return {
+            run: async (query: {
+              json: boolean
+              sql: string
+              params: { id: number }
+            }) => {
+              expect(query.sql).toBe(
+                'SELECT id, idSub, a, b FROM CompositeKeyTests WHERE id=@id AND idSub=@idSub LIMIT 1',
+              )
+              expect(query.json).toBe(false)
+              expect(query.params).toEqual({ id: 123, idSub: 'foo' })
+              return Promise.resolve([
+                [
+                  {
+                    toJSON: () => {
+                      return {
+                        id: 123,
+                        a: 'abcd',
+                        b: 'efg',
+                      }
+                    },
+                  },
+                ],
+              ])
+            },
+          }
+        },
+      }
+    })
+
+    const transactionManager = new TransactionManager(null)
+    const target = new CompositeKeyTestRepository(
+      transactionManager,
+      CompositeKeyTest,
+    )
+    let actual: CompositeKeyTest | null = await target.findOne({
+      where: {
+        id: 123,
+        idSub: 'foo',
+      },
+    })
+    const expectResult = new CompositeKeyTest()
+    expectResult.id = 123
+    expectResult.a = 'abcd'
+    expectResult.b = 'efg'
+    expect(actual).toEqual(expectResult)
+  })
+
+  test('findOne simple key test', async () => {
+    TransactionManagerMock.mockImplementationOnce(() => {
+      return {
+        getDb: (): any => {
+          return {
+            run: async (query: {
+              json: boolean
+              sql: string
+              params: { id: number }
+            }) => {
+              expect(query.sql).toBe(
+                'SELECT id, idSub, a, b FROM CompositeKeyTests WHERE id=@id LIMIT 1',
+              )
+              expect(query.json).toBe(false)
+              expect(query.params).toEqual({ id: 123 })
+              return Promise.resolve([
+                [
+                  {
+                    toJSON: () => {
+                      return {
+                        id: 123,
+                        a: 'abcd',
+                        b: 'efg',
+                      }
+                    },
+                  },
+                ],
+              ])
+            },
+          }
+        },
+      }
+    })
+
+    const transactionManager = new TransactionManager(null)
+    const target = new CompositeKeyTestRepository(
+      transactionManager,
+      CompositeKeyTest,
+    )
+    let actual: CompositeKeyTest | null = await target.findOne({
+      where: {
+        id: 123,
+      },
+    })
+    const expectResult = new CompositeKeyTest()
+    expectResult.id = 123
+    expectResult.a = 'abcd'
+    expectResult.b = 'efg'
+    expect(actual).toEqual(expectResult)
+  })
+
+  test('findOne simple key test with order', async () => {
+    TransactionManagerMock.mockImplementationOnce(() => {
+      return {
+        getDb: (): any => {
+          return {
+            run: async (query: {
+              json: boolean
+              sql: string
+              params: { id: number }
+            }) => {
+              expect(query.sql).toBe(
+                'SELECT id, idSub, a, b FROM CompositeKeyTests WHERE id=@id ORDER BY id ASC, b DESC LIMIT 1',
+              )
+              expect(query.json).toBe(false)
+              expect(query.params).toEqual({ id: 123 })
+              return Promise.resolve([
+                [
+                  {
+                    toJSON: () => {
+                      return {
+                        id: 123,
+                        a: 'abcd',
+                        b: 'efg',
+                      }
+                    },
+                  },
+                ],
+              ])
+            },
+          }
+        },
+      }
+    })
+
+    const transactionManager = new TransactionManager(null)
+    const target = new CompositeKeyTestRepository(
+      transactionManager,
+      CompositeKeyTest,
+    )
+    let actual: CompositeKeyTest | null = await target.findOne({
+      where: {
+        id: 123,
+      },
+      order: {
+        id: 'ASC',
+        b: 'DESC',
+      },
+    })
+    const expectResult = new CompositeKeyTest()
+    expectResult.id = 123
+    expectResult.a = 'abcd'
+    expectResult.b = 'efg'
+    expect(actual).toEqual(expectResult)
+  })
+})


### PR DESCRIPTION
* add findMany function to Repository

```
 @Entity('CompositeKeyTests')
export class CompositeKeyTest {
  @PrimaryColumn()
  id: number

  @PrimaryColumn()
  idSub: string

  @Column()
  a

  @Column()
  b
 }

  const actual: CompositeKeyTest[] = await target.findMany({
      where: {
        id: 123,
      },
      order: {
        b: 'asc',
        a: 'DESC',
        idSub: 'ASC',
      },
    })
```